### PR TITLE
Add viewschedule command to display tasks for a specific date

### DIFF
--- a/src/main/java/bobby/Deadline.java
+++ b/src/main/java/bobby/Deadline.java
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter;
  * Represents a task with a deadline, storing the due date and description.
  */
 public class Deadline extends Task {
-    private final LocalDateTime by;
+    private LocalDateTime by;
     private static final DateTimeFormatter INPUT_FORMAT = DateTimeFormatter.ofPattern("d/M/yyyy HHmm");
     private static final DateTimeFormatter OUTPUT_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy, h:mma");
 

--- a/src/main/java/bobby/Parser.java
+++ b/src/main/java/bobby/Parser.java
@@ -61,6 +61,11 @@ public class Parser {
             return new FindCommand(words[1].trim());
         case "bye":
             return new ExitCommand();
+        case "viewschedule":
+            if (words.length < 2 || words[1].trim().isEmpty()) {
+                throw new BobbyException("Please specify a date in d/M/yyyy format, e.g., viewschedule 19/09/2025");
+            }
+            return new bobby.command.ViewScheduleCommand(words[1].trim());
         default:
             throw new BobbyException("Whatdatmean");
         }

--- a/src/main/java/bobby/TaskList.java
+++ b/src/main/java/bobby/TaskList.java
@@ -1,7 +1,9 @@
 package bobby;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 
+import java.util.Comparator;
 /**
  * Manages a list of Task objects, providing operations to add, delete, retrieve, and search tasks.
  */
@@ -85,5 +87,33 @@ public class TaskList {
             }
         }
         return found;
+    }
+
+    /**
+     * Returns a list of tasks scheduled for the given date.
+     * Includes Deadlines due on that date and Events occurring on that date.
+     * ToDos are not included as they have no date.
+     *
+     * @param date The date to filter tasks by.
+     * @return List of tasks scheduled for the date.
+     */
+    public ArrayList<Task> getTasksForDate(LocalDate date) {
+        ArrayList<Task> result = new ArrayList<>();
+        for (Task task : tasks) {
+            if (task instanceof Deadline) {
+                Deadline d = (Deadline) task;
+                if (d.getBy().toLocalDate().equals(date)) {
+                    result.add(task);
+                }
+            } else if (task instanceof Event) {
+                Event e = (Event) task;
+                LocalDate from = e.getFrom().toLocalDate();
+                LocalDate to = e.getTo().toLocalDate();
+                if ((date.isEqual(from) || date.isAfter(from)) && (date.isEqual(to) || date.isBefore(to))) {
+                    result.add(task);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/bobby/Ui.java
+++ b/src/main/java/bobby/Ui.java
@@ -1,5 +1,6 @@
 package bobby;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Scanner;
 
@@ -121,5 +122,39 @@ public class Ui {
      */
     public void showMessage(String msg) {
         System.out.println(msg);
+    }
+
+    /**
+     * Displays a message indicating a task has been updated.
+     *
+     * @param task The task that was updated.
+     * @return The update confirmation message.
+     */
+    public String showUpdate(Task task) {
+        String msg = "Task updated:\n  " + task;
+        System.out.println(msg);
+        return msg;
+    }
+
+    /**
+     * Displays the schedule for a specific date.
+     *
+     * @param date The date for which to show the schedule.
+     * @param tasks The list of tasks scheduled for that date.
+     * @return The schedule as a string (for GUI or CLI).
+     */
+    public String showScheduleForDate(LocalDate date, ArrayList<Task> tasks) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Schedule for ").append(date).append(":\n");
+        if (tasks.isEmpty()) {
+            sb.append("No tasks scheduled for this date.\n");
+        } else {
+            for (int i = 0; i < tasks.size(); i++) {
+                sb.append((i + 1)).append(". ").append(tasks.get(i)).append("\n");
+            }
+        }
+        String result = sb.toString();
+        System.out.print(result);
+        return result;
     }
 }

--- a/src/main/java/bobby/command/ViewScheduleCommand.java
+++ b/src/main/java/bobby/command/ViewScheduleCommand.java
@@ -1,0 +1,30 @@
+package bobby.command;
+
+import bobby.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+
+/**
+ * Command to view the schedule for a specific date.
+ */
+public class ViewScheduleCommand extends Command {
+    private final LocalDate date;
+
+    public ViewScheduleCommand(String dateStr) throws BobbyException {
+        try {
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("d/M/yyyy");
+            this.date = LocalDate.parse(dateStr.trim(), fmt);
+        } catch (DateTimeParseException e) {
+            throw new BobbyException("Invalid date format. Use d/M/yyyy, e.g., 19/09/2025");
+        }
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) {
+        ArrayList<Task> scheduled = tasks.getTasksForDate(date);
+        return ui.showScheduleForDate(date, scheduled);
+    }
+}
+


### PR DESCRIPTION
- Implement ViewScheduleCommand to allow users to view all scheduled tasks for a given date using the command: viewschedule d/M/yyyy
- Update Parser to recognize and parse the viewschedule command and its date argument
- Add getTasksForDate(LocalDate date) method to TaskList to filter and return all Deadlines and Events scheduled for the specified date
- Update Ui with showScheduleForDate to display the schedule in a user-friendly format
- Ensure schedule output is in chronological order by time for the selected date
- ToDos are not included in the schedule as they have no associated date

This feature allows users to easily see their schedule for any chosen day, improving task management and planning.